### PR TITLE
all: use named returns for proper defers + fix fmt.Errorf misuse

### DIFF
--- a/common.go
+++ b/common.go
@@ -53,20 +53,20 @@ func NewVersionRequiredError(req VersionInfo, ver VersionInfo) error {
 // CheckVersion compares the current version with the required version
 func CheckVersion(ver VersionInfo, req VersionInfo) error {
 	if ver.Major != req.Major {
-		if (ver.Major > req.Major){
+		if ver.Major > req.Major {
 			return nil
 		}
 		return NewVersionRequiredError(req, ver)
 	}
 
 	if ver.Minor != req.Minor {
-		if (ver.Minor > req.Minor) {
+		if ver.Minor > req.Minor {
 			return nil
 		}
 		return NewVersionRequiredError(req, ver)
 	}
 
-	if (ver.Patch >= req.Patch){
+	if ver.Patch >= req.Patch {
 		return nil
 	}
 	return NewVersionRequiredError(req, ver)
@@ -95,7 +95,7 @@ func GetBip32bytesv2(bip44Path []uint32, hardenCount int) ([]byte, error) {
 		return nil, fmt.Errorf("path should contain 5 elements")
 	}
 	for index, element := range bip44Path {
-		pos := index*4
+		pos := index * 4
 		value := element
 		if index < hardenCount {
 			value = 0x80000000 | element

--- a/common_test.go
+++ b/common_test.go
@@ -34,7 +34,7 @@ func Test_PathGeneration0(t *testing.T) {
 	pathBytes, err := GetBip32bytesv1(bip32Path, 0)
 
 	if err != nil {
-		t.Fatalf( "Detected error, err: %s\n", err.Error())
+		t.Fatalf("Detected error, err: %s\n", err.Error())
 	}
 
 	fmt.Printf("Path: %x\n", pathBytes)
@@ -106,7 +106,7 @@ func Test_PathGeneration0v2(t *testing.T) {
 	pathBytes, err := GetBip32bytesv2(bip32Path, 0)
 
 	if err != nil {
-		t.Fatalf( "Detected error, err: %s\n", err.Error())
+		t.Fatalf("Detected error, err: %s\n", err.Error())
 	}
 
 	fmt.Printf("Path: %x\n", pathBytes)

--- a/user_app.go
+++ b/user_app.go
@@ -17,7 +17,7 @@
 package ledger_cosmos_go
 
 import (
-	"fmt"
+	"errors"
 	"math"
 
 	"github.com/cosmos/ledger-go"
@@ -40,31 +40,32 @@ type LedgerCosmos struct {
 }
 
 // FindLedgerCosmosUserApp finds a Cosmos user app running in a ledger device
-func FindLedgerCosmosUserApp() (*LedgerCosmos, error) {
+func FindLedgerCosmosUserApp() (_ *LedgerCosmos, rerr error) {
 	ledgerAPI, err := ledger_go.FindLedger()
-
 	if err != nil {
 		return nil, err
 	}
 
-	app := LedgerCosmos{ledgerAPI, VersionInfo{}}
-	appVersion, err := app.GetVersion()
+	defer func() {
+		if rerr != nil {
+			ledgerAPI.Close()
+		}
+	}()
 
+	app := &LedgerCosmos{ledgerAPI, VersionInfo{}}
+	appVersion, err := app.GetVersion()
 	if err != nil {
-		defer ledgerAPI.Close()
 		if err.Error() == "[APDU_CODE_CLA_NOT_SUPPORTED] Class not supported" {
-			return nil, fmt.Errorf("are you sure the Cosmos app is open?")
+			err = errors.New("are you sure the Cosmos app is open?")
 		}
 		return nil, err
 	}
 
-	err = app.CheckVersion(*appVersion)
-	if err != nil {
-		defer ledgerAPI.Close()
+	if err := app.CheckVersion(*appVersion); err != nil {
 		return nil, err
 	}
 
-	return &app, err
+	return app, err
 }
 
 // Close closes a connection with the Cosmos user app
@@ -85,7 +86,7 @@ func (ledger *LedgerCosmos) CheckVersion(ver VersionInfo) error {
 	case 2:
 		return CheckVersion(ver, VersionInfo{0, 2, 1, 0})
 	default:
-		return fmt.Errorf("App version is not supported")
+		return errors.New("App version is not supported")
 	}
 }
 
@@ -99,7 +100,7 @@ func (ledger *LedgerCosmos) GetVersion() (*VersionInfo, error) {
 	}
 
 	if len(response) < 4 {
-		return nil, fmt.Errorf("invalid response")
+		return nil, errors.New("invalid response")
 	}
 
 	ledger.version = VersionInfo{
@@ -121,7 +122,7 @@ func (ledger *LedgerCosmos) SignSECP256K1(bip32Path []uint32, transaction []byte
 	case 2:
 		return ledger.signv2(bip32Path, transaction)
 	default:
-		return nil, fmt.Errorf("App version is not supported")
+		return nil, errors.New("App version is not supported")
 	}
 }
 
@@ -159,7 +160,7 @@ func (ledger *LedgerCosmos) GetBip32bytes(bip32Path []uint32, hardenCount int) (
 			return nil, err
 		}
 	default:
-		return nil, fmt.Errorf("App version is not supported")
+		return nil, errors.New("App version is not supported")
 	}
 
 	return pathBytes, nil
@@ -197,13 +198,13 @@ func (ledger *LedgerCosmos) signv1(bip32Path []uint32, transaction []byte) ([]by
 				errorMsg := string(response)
 				switch errorMsg {
 				case "ERROR: JSMN_ERROR_NOMEM":
-					return nil, fmt.Errorf("Not enough tokens were provided")
+					return nil, errors.New("Not enough tokens were provided")
 				case "PARSER ERROR: JSMN_ERROR_INVAL":
-					return nil, fmt.Errorf("Unexpected character in JSON string")
+					return nil, errors.New("Unexpected character in JSON string")
 				case "PARSER ERROR: JSMN_ERROR_PART":
-					return nil, fmt.Errorf("The JSON string is not a complete.")
+					return nil, errors.New("The JSON string is not a complete.")
 				}
-				return nil, fmt.Errorf(errorMsg)
+				return nil, errors.New(errorMsg)
 			}
 			return nil, err
 		}
@@ -256,17 +257,17 @@ func (ledger *LedgerCosmos) signv2(bip32Path []uint32, transaction []byte) ([]by
 				errorMsg := string(response)
 				switch errorMsg {
 				case "ERROR: JSMN_ERROR_NOMEM":
-					return nil, fmt.Errorf("Not enough tokens were provided")
+					return nil, errors.New("Not enough tokens were provided")
 				case "PARSER ERROR: JSMN_ERROR_INVAL":
-					return nil, fmt.Errorf("Unexpected character in JSON string")
+					return nil, errors.New("Unexpected character in JSON string")
 				case "PARSER ERROR: JSMN_ERROR_PART":
-					return nil, fmt.Errorf("The JSON string is not a complete.")
+					return nil, errors.New("The JSON string is not a complete.")
 				}
-				return nil, fmt.Errorf(errorMsg)
+				return nil, errors.New(errorMsg)
 			}
 			if err.Error() == "[APDU_CODE_DATA_INVALID] Referenced data reversibly blocked (invalidated)" {
 				errorMsg := string(response)
-				return nil, fmt.Errorf(errorMsg)
+				return nil, errors.New(errorMsg)
 			}
 			return nil, err
 		}
@@ -285,13 +286,13 @@ func (ledger *LedgerCosmos) signv2(bip32Path []uint32, transaction []byte) ([]by
 // this command requires user confirmation in the device
 func (ledger *LedgerCosmos) getAddressPubKeySECP256K1(bip32Path []uint32, hrp string, requireConfirmation bool) (pubkey []byte, addr string, err error) {
 	if len(hrp) > 83 {
-		return nil, "", fmt.Errorf("hrp len should be <10")
+		return nil, "", errors.New("hrp len should be <10")
 	}
 
 	hrpBytes := []byte(hrp)
 	for _, b := range hrpBytes {
 		if !validHRPByte(b) {
-			return nil, "", fmt.Errorf("all characters in the HRP must be in the [33, 126] range")
+			return nil, "", errors.New("all characters in the HRP must be in the [33, 126] range")
 		}
 	}
 
@@ -318,7 +319,7 @@ func (ledger *LedgerCosmos) getAddressPubKeySECP256K1(bip32Path []uint32, hrp st
 		return nil, "", err
 	}
 	if len(response) < 35+len(hrp) {
-		return nil, "", fmt.Errorf("Invalid response")
+		return nil, "", errors.New("Invalid response")
 	}
 
 	pubkey = response[0:33]

--- a/user_app_test.go
+++ b/user_app_test.go
@@ -273,6 +273,6 @@ func Test_UserSign_Fails(t *testing.T) {
 	errMessage := err.Error()
 
 	if errMessage != "Invalid character in JSON string" && errMessage != "Unexpected characters" {
-		assert.Fail(t, "Unexpected error message returned: " + errMessage )
+		assert.Fail(t, "Unexpected error message returned: "+errMessage)
 	}
 }

--- a/validator_app_test.go
+++ b/validator_app_test.go
@@ -25,7 +25,7 @@ import (
 func Test_ValGetVersion(t *testing.T) {
 	validatorApp, err := FindLedgerTendermintValidatorApp()
 	if err != nil {
-		t.Fatalf( err.Error())
+		t.Fatalf(err.Error())
 	}
 	defer validatorApp.Close()
 
@@ -42,7 +42,7 @@ func Test_ValGetVersion(t *testing.T) {
 func Test_ValGetPublicKey(t *testing.T) {
 	validatorApp, err := FindLedgerTendermintValidatorApp()
 	if err != nil {
-		t.Fatalf( err.Error())
+		t.Fatalf(err.Error())
 	}
 	defer validatorApp.Close()
 


### PR DESCRIPTION
To ensure that the ledger device is properly invoked on errors,
this change uses a defer with a named return value for the error
and invokes .Close when the error is non-nil, previously there were
conditions in which the ledger device would be left unclosed hence
leaking.

While here, also removed superfluous uses of fmt.Errorf being used to
create errors yet without formattable arguments. This change instead
uses the "errors" package and cuts out the unnecessary "fmt" dependency
which will help reduce binary size of the ledger app.

While here, also ran `go fmt` on all the code which fixed up some
code style issues.

Fixes #15
Fixes #16
Fixes #17