### PR TITLE
fix: improve UX by sending major version info

### DIFF
--- a/user_app.go
+++ b/user_app.go
@@ -18,6 +18,7 @@ package ledger_cosmos_go
 
 import (
 	"errors"
+	"fmt"
 	"math"
 
 	ledger_go "github.com/zondax/ledger-go"
@@ -66,7 +67,7 @@ func FindLedgerCosmosUserApp() (_ *LedgerCosmos, rerr error) {
 		return nil, err
 	}
 
-	return app, err
+	return app, nil
 }
 
 // Close closes a connection with the Cosmos user app
@@ -81,13 +82,13 @@ func (ledger *LedgerCosmos) CheckVersion(ver VersionInfo) error {
 		return err
 	}
 
-	switch version.Major {
+	switch major := version.Major; major {
 	case 1:
 		return CheckVersion(ver, VersionInfo{0, 1, 5, 1})
 	case 2:
 		return CheckVersion(ver, VersionInfo{0, 2, 1, 0})
 	default:
-		return errors.New("App version is not supported")
+		return fmt.Errorf("App version %d is not supported", major)
 	}
 }
 
@@ -118,13 +119,13 @@ func (ledger *LedgerCosmos) GetVersion() (*VersionInfo, error) {
 // SIGN_MODE_LEGACY_AMINO_JSON (P2=0) or SIGN_MODE_TEXTUAL (P2=1).
 // this command requires user confirmation in the device
 func (ledger *LedgerCosmos) SignSECP256K1(bip32Path []uint32, transaction []byte, p2 byte) ([]byte, error) {
-	switch ledger.version.Major {
+	switch major := ledger.version.Major; major {
 	case 1:
 		return ledger.signv1(bip32Path, transaction)
 	case 2:
 		return ledger.signv2(bip32Path, transaction, p2)
 	default:
-		return nil, errors.New("App version is not supported")
+		return nil, fmt.Errorf("App version %d is not supported", major)
 	}
 }
 
@@ -150,7 +151,7 @@ func (ledger *LedgerCosmos) GetBip32bytes(bip32Path []uint32, hardenCount int) (
 	var pathBytes []byte
 	var err error
 
-	switch ledger.version.Major {
+	switch major := ledger.version.Major; major {
 	case 1:
 		pathBytes, err = GetBip32bytesv1(bip32Path, 3)
 		if err != nil {
@@ -162,7 +163,7 @@ func (ledger *LedgerCosmos) GetBip32bytes(bip32Path []uint32, hardenCount int) (
 			return nil, err
 		}
 	default:
-		return nil, errors.New("App version is not supported")
+		return nil, fmt.Errorf("App version %d is not supported", major)
 	}
 
 	return pathBytes, nil


### PR DESCRIPTION
This change improves user experience (UX) by sending over the major version information. While here, also fixed up an unclear return.

Fixes #50
Fixes #51